### PR TITLE
- Update version of dependency libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ Of course, you need to have a translation **JSON** file to pass it to TranslateP
   }
 }
 ```
+
+By default the ```Translate``` component wraps the tranlated text into a ```<span>``` element. Additionally, you can use the prop ```useRawText``` from the ```Translate``` component to render the tranlated text with no wrapping. This will be useful to render the text in elements that don't support nested ```<span>``` as well as for other user cases like placeholders in ```<input>``` elements. E.g.
+````
+<select className="selectClass">
+  <option value="phone"><Translate useRawText={true}>Phone</Translate></option>
+  <option value="email"><Translate useRawText={true}>Email</Translate></option>
+  <option value="textMessage"><Translate useRawText={true}>Text Message</Translate></option>
+</select>
+...
+...
+<input type="text" name="phone" className="form-control phone" placeholder={<Translate useRawText={true}>Número Telefónico</Translate>} />
+...
+...
+```
+
 **The default language passed to TranslateProvider is the key of your translation objects.**
 
 # Extracting strings

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   "homepage": "https://github.com/zamarrowski/translate-components#readme",
   "dependencies": {
     "glob": "7.1.1",
-    "prop-types": "15.5.8",
-    "react": "15.5.4",
-    "react-dom": "15.5.4"
+    "prop-types": "15.6.2",
+    "react": "16.4.2",
+    "react-dom": "16.4.2"
   },
   "devDependencies": {
     "ava": "0.19.1",

--- a/src/Translate.js
+++ b/src/Translate.js
@@ -7,6 +7,7 @@ class Translate extends Component {
     this.translations = JSON.parse(context.translations)
     this.defaultLanguage = context.defaultLanguage
     this.debugMode = context.debugMode
+    this.useRawText = props.useRawText // useful to bind the text inside input placeholder, inside <option> elements, or when a <span> cannot be used
     this.state = {
       language: this.defaultLanguage
     }
@@ -16,20 +17,29 @@ class Translate extends Component {
     window.addEventListener('reactTranslateChangeLanguage', this._changeLanguage.bind(this))
   }
 
+  componentWillUnmount() {
+    window.removeEventListener('reactTranslateChangeLanguage', this._changeLanguage.bind(this))
+  }
+
   render() {
     return (
-      <span style={this._getDebugModeStyles(this.props.children)}>{this._getText(this.props.children)}</span>
+      this.useRawText
+        ? this._getText(this.props.children)
+        : <span style={this._getDebugModeStyles(this.props.children)}>{this._getText(this.props.children)}</span>
     )
   }
 
   _getText(text) {
-    if (this.state.language != this.defaultLanguage && text) {
+    if (this.state.language !== this.defaultLanguage && text) {
       if (this.translations[text] && this.translations[text][this.state.language]) {
         return this.translations[text][this.state.language]
       } else {
         return text
       }
-    } else {
+    } else if (this.translations[text] && this.translations[text][this.state.language]) {
+      return this.translations[text][this.state.language]
+    }
+    else {
       return text
     }
   }
@@ -52,5 +62,13 @@ Translate.contextTypes = {
   defaultLanguage: PropTypes.string,
   debugMode: PropTypes.bool
 }
+
+Translate.propTypes = {
+  translations: PropTypes.object,
+  defaultLanguage: PropTypes.string,
+  debugMode: PropTypes.bool,
+  useRawText: PropTypes.bool,
+  children: PropTypes.node
+};
 
 export default Translate

--- a/src/TranslateProvider.js
+++ b/src/TranslateProvider.js
@@ -25,4 +25,11 @@ TranslateProvider.childContextTypes = {
   debugMode: PropTypes.bool
 }
 
+TranslateProvider.propTypes = {
+  translations: PropTypes.any,
+  defaultLanguage: PropTypes.string,
+  debugMode: PropTypes.bool,
+  children: PropTypes.node
+};
+
 export default TranslateProvider


### PR DESCRIPTION
- Add new prop in Translate component to return only the translated text not wrapped in a <span>. This is useful to bind the text inside <option> elements, input placeholders, etc
- Remove the event listener in the componentWillUnmount
- Refactor _getText so that the translated text is return when the default language equals state.language. In some scenarios the text is not rendered when using only the defaultLanguage prop
- Add PropTypes validations